### PR TITLE
Default @posts to main query and accept query arg

### DIFF
--- a/src/Directives/WordPress.php
+++ b/src/Directives/WordPress.php
@@ -20,9 +20,14 @@ return [
     },
 
     /** Create @posts Blade directive */
-    'posts' => function () {
-        return "<?php if (\$query->have_posts()) : ?>".
-               "<?php while (\$query->have_posts()) : \$query->the_post(); ?>";
+    'posts' => function ($expression) {
+        if ($expression) {
+            return "<?php if ({$expression}->have_posts()) : ?>".
+                "<?php while ({$expression}->have_posts()) : {$expression}->the_post(); ?>";
+        }
+
+        return "<?php if (have_posts()) : ?>".
+            "<?php while (have_posts()) : the_post(); ?>";
     },
 
     /** Create @endposts Blade directive */


### PR DESCRIPTION
Thanks for this set of directives, @Log1x!

For your consideration...

This PR changes `@posts` to provide greater flexibility:

1. Now defaults to the main query instead of `$query`
2. Now can accept an optional argument so that you can pass a query to be used in

This would break backwards compatibility with previous `@posts` usage that defaulted to using `$query`.

Options for moving forward:

1. Accept breaking change and use semver / docs to communicate it appropriately and help users know what they need to update (`@posts` -> `@posts($query)`)
2. Modify this PR so that if no query is passed to the directive and `$query` exists it defaults to that instead of to the main query

Updated docs:

#### @posts

`@posts` begins the post loop. It is wrapped in a `have_posts()` conditional and thus will return `null` if no posts are found.

`@endposts` is available to end your loop and `have_posts()` conditional as well as resetting your loop with [`wp_reset_postdata()`](https://codex.wordpress.org/Function_Reference/wp_reset_postdata).

`@posts` defaults to the main query, but it accepts a `WP_Query` instance as an optional argument. If the argument is provided, `@posts` will use that query instead.

```php
@posts
  <h2 class="entry-title">{!! get_the_title() !!}</h2>
  <div class="entry-content">
    @php the_content() @endphp
  </div>
@endposts

@posts($other_query)
  <h2 class="entry-title">{!! get_the_title() !!}</h2>
  <div class="entry-content">
    @php the_content() @endphp
  </div>
@endposts
```