### PR TITLE
Added wordpress filter to override default namespace.

### DIFF
--- a/src/Directives.php
+++ b/src/Directives.php
@@ -16,6 +16,13 @@ class Directives
     ];
 
     /**
+     * Namespace
+     *
+     * @var string
+     */
+    private $namespace;
+
+    /**
      * Create a new Directives instance.
      *
      * @return void
@@ -23,6 +30,9 @@ class Directives
     public function __construct()
     {
         add_action('after_setup_theme', function () {
+            // Allow themes to override 'App' namespace, default: App;
+            $this->namespace = apply_filters('log1x/sage-directives/namespace', 'App');
+
             if (! $this->blade()) {
                 return;
             }
@@ -71,8 +81,10 @@ class Directives
      */
     protected function blade()
     {
-        if (function_exists('App\sage')) {
-            return \App\sage('blade')->compiler();
+        $sage = "\\{$this->namespace}\\sage";
+
+        if (function_exists($sage)) {
+            return $sage('blade')->compiler();
         }
 
         if (function_exists('Roots\app')) {

--- a/src/Directives.php
+++ b/src/Directives.php
@@ -20,7 +20,7 @@ class Directives
      *
      * @var string
      */
-    private $namespace;
+    protected $namespace = 'App';
 
     /**
      * Create a new Directives instance.
@@ -30,8 +30,7 @@ class Directives
     public function __construct()
     {
         add_action('after_setup_theme', function () {
-            // Allow themes to override 'App' namespace, default: App;
-            $this->namespace = apply_filters('log1x/sage-directives/namespace', 'App');
+            $this->namespace = apply_filters('log1x/sage-directives/namespace', $this->namespace);
 
             if (! $this->blade()) {
                 return;


### PR DESCRIPTION
Added filter to overriding the default namespace, similar to how soberwp does it.
If no filter is applied, default App namespace will be used instead.