### PR TITLE
Add @wpbodyopen directive

### DIFF
--- a/docs/usage/wordpress.md
+++ b/docs/usage/wordpress.md
@@ -484,3 +484,7 @@ This is just a directive version of [`wp_footer`](https://codex.wordpress.org/Fu
 ```php
 @bodyclass('add-me')
 ```
+
+## @wpbodyopen
+
+This is a directive version of [`wp_body_open`](https://developer.wordpress.org/reference/functions/wp_body_open/) except that it will work on WordPress versions below 5.2.

--- a/src/Directives/WordPress.php
+++ b/src/Directives/WordPress.php
@@ -488,12 +488,16 @@ return [
 
     /*
     |---------------------------------------------------------------------
-    | @bodyclass
+    | @bodyclass / @wpbodyopen
     |---------------------------------------------------------------------
     */
 
     'bodyclass' => function ($expression) {
         return "<?php body_class({$expression}); ?>";
+    },
+
+    'wpbodyopen' => function () {
+        return "<?php if (function_exists('wp_body_open')) { wp_body_open(); } else { do_action('wp_body_open'); } ?>";
     },
 
     /*


### PR DESCRIPTION
Adds a `@wpbodyopen` directive.

Since this is a new function in WordPress 5.2, the implementation checks for the `wp_body_open()` function. If it doesn't exist, it just calls the `wp_body_open` action hook (which is all that `wp_body_open()` currently does anyway).

fixes #45 