### PR TITLE
Added @hasfields and @endhasfields

### DIFF
--- a/src/Directives/ACF.php
+++ b/src/Directives/ACF.php
@@ -17,7 +17,7 @@ return [
 
     /*
     |---------------------------------------------------------------------
-    | @fields / @endfields
+    | @fields / @endfields / @hasfields / @endhasfields
     |---------------------------------------------------------------------
     */
 
@@ -35,6 +35,20 @@ return [
 
     'endfields' => function () {
         return "<?php endwhile; endif; ?>";
+    },
+
+    'hasfields' => function ($expression) {
+        if (Str::contains($expression, ',')) {
+            $expression = Util::parse($expression);
+
+            return "<?php if (have_rows({$expression->get(0)}, {$expression->get(1)})) : ?>";
+        }
+
+        return "<?php if (have_rows({$expression})) : ?>";
+    },
+
+    'endhasfields' => function () {
+        return "<?php endif; ?>";
     },
 
     /*


### PR DESCRIPTION
While [`@fields`](https://github.com/Log1x/sage-directives/blob/master/src/Directives/ACF.php#L28) does have a check if the field exists, sometimes you want to use only check if the field exists without having the `while` that comes with using `@fields`.

For example, today I was working on a Swiper slider. This is my code before:
```blade
<div class="swiper-wrapper">
    @fields('images')
        <div class="swiper-slide"></div>
    @endfields
</div>
```

However, when there are no images set in ACF, you still get the `div.swiper-wrapper` in your DOM. So I had to wrap it in

```blade
@if(have_rows('images'))
    <div class="swiper-wrapper">
        @fields('images')
            <div class="swiper-slide"></div>
        @endfields
    </div>
@endif
```

So, when there are no images selected, the `div.swiper-wrapper` doens't exist in the DOM.

However, wouldn't it be nice to do:
```blade
@hasfields('images')
    <div class="swiper-wrapper">
        @fields('images')
            <div class="swiper-slide"></div>
        @endfields
    </div>
@endhasfields
```