### PR TITLE
Fix errors for @term

### DIFF
--- a/src/Directives/WordPress.php
+++ b/src/Directives/WordPress.php
@@ -306,29 +306,29 @@ return [
         $expression = Util::parse($expression);
 
         if (! empty($expression->get(2))) {
-            return "<?php if (collect(get_the_terms({$expression->get(1)}, {$expression->get(0)}))->isNotEmpty()) : ?>" . // phpcs:ignore
-                   "<a href=\"<?= get_term_link(collect(get_the_terms({$expression->get(1)}, {$expression->get(0)}))->shift()->term_ID); ?>\">" . // phpcs:ignore
-                   "<?= collect(get_the_terms({$expression->get(1)}, {$expression->get(0)}))->shift()->name(); ?>" .
+            return "<?php if (get_the_terms({$expression->get(1)}, {$expression->get(0)})) : ?>" . // phpcs:ignore
+                   "<a href=\"<?= get_term_link(collect(get_the_terms({$expression->get(1)}, {$expression->get(0)}))->shift()->term_id); ?>\">" . // phpcs:ignore
+                   "<?= collect(get_the_terms({$expression->get(1)}, {$expression->get(0)}))->shift()->name; ?>" .
                    "</a>" .
                    "<?php endif; ?>";
         }
 
         if (! empty($expression->get(1))) {
             if ($expression->get(1) === 'true') {
-                return "<?php if (collect(get_the_terms(get_the_ID(), {$expression->get(0)}))->isNotEmpty()) : ?>" .
-                       "<a href=\"<?= get_term_link(collect(get_the_terms(get_the_ID(), {$expression->get(0)}))->shift()->term_ID); ?>\">" . // phpcs:ignore
-                       "<?= collect(get_the_terms(get_the_ID(), {$expression->get(0)}))->shift()->name(); ?>" .
+                return "<?php if (get_the_terms(get_the_ID(), {$expression->get(0)})) : ?>" .
+                       "<a href=\"<?= get_term_link(collect(get_the_terms(get_the_ID(), {$expression->get(0)}))->shift()->term_id); ?>\">" . // phpcs:ignore
+                       "<?= collect(get_the_terms(get_the_ID(), {$expression->get(0)}))->shift()->name; ?>" .
                        "</a>" .
                        "<?php endif; ?>";
             }
 
-            return "<?php if (collect(get_the_terms({$expression->get(1)}, {$expression->get(0)}))->isNotEmpty()) : ?>" . // phpcs:ignore
-                   "<?= collect(get_the_terms({$expression->get(1)}, {$expression->get(0)}))->shift()->name(); ?>" .
+            return "<?php if (get_the_terms({$expression->get(1)}, {$expression->get(0)})) : ?>" . // phpcs:ignore
+                   "<?= collect(get_the_terms({$expression->get(1)}, {$expression->get(0)}))->shift()->name; ?>" .
                    "<?php endif; ?>";
         }
 
         if (! empty($expression->get(0))) {
-            return "<?php if (collect(get_the_terms(get_the_ID(), {$expression->get(0)}))->isNotEmpty()) : ?>" .
+            return "<?php if (get_the_terms(get_the_ID(), {$expression->get(0)})) : ?>" .
                    "<?= collect(get_the_terms(get_the_ID(), {$expression->get(0)}))->shift()->name; ?>" .
                    "<?php endif; ?>";
         }


### PR DESCRIPTION
1. →name() is not a method
2. `get_the_terms()` might return false or error not always an array like `get_the_category()` which makes it pass the condition when terms are empty and cause errors such as `Object of class WP_Term could not be converted to string at /app/..`
3. correct key for getting term ID