### PR TITLE
update wp_query in "@posts" directive to return any post type.

### DIFF
--- a/src/Directives/WordPress.php
+++ b/src/Directives/WordPress.php
@@ -40,7 +40,8 @@ return [
                            ->map(function (\$post) {
                                return is_a(\$post, 'WP_Post') ? \$post->ID : \$post;
                            })->all())
-                       ->put('orderby', 'post__in');
+                       ->put('orderby', 'post__in')
+                       ->put('post_type', 'any');
                    ?>" .
                    "<?php endif; ?>" .
 


### PR DESCRIPTION
This allows use of code like:

@posts(get_field('artists'))

with "artists" being an array of "artist" post types returned by an ACF relationship field. A wp_query defaults to returning just "post" type posts.