### PR TITLE
Fixed @field not accepting 'option' as second argument

### DIFF
--- a/src/Directives/ACF.php
+++ b/src/Directives/ACF.php
@@ -65,7 +65,7 @@ return [
                 return "<?= get_field({$expression->get(0)}, {$expression->get(2)})[{$expression->get(1)}]; ?>";
             }
 
-            if (! is_string($expression->get(1))) {
+            if (! is_string($expression->get(1)) || $expression->get(1) == 'option') {
                 return "<?= get_field({$expression->get(0)}, {$expression->get(1)}); ?>";
             }
 

--- a/src/Directives/ACF.php
+++ b/src/Directives/ACF.php
@@ -65,7 +65,7 @@ return [
                 return "<?= get_field({$expression->get(0)}, {$expression->get(2)})[{$expression->get(1)}]; ?>";
             }
 
-            if (! is_string($expression->get(1)) || $expression->get(1) == 'option') {
+            if (! is_string($expression->get(1)) || Util::strip($expression->get(1)) == "option") {
                 return "<?= get_field({$expression->get(0)}, {$expression->get(1)}); ?>";
             }
 


### PR DESCRIPTION
As the second argument isn't accepting a string right now, the 'option' argument for the ACF Option Page isn't working. Adding a check if the second argument is 'option' fixes this and only accepts 'option' as an argument.