### PR TITLE
Fix issues with field, hasfield, isfield post ID parsing

### DIFF
--- a/src/Directives/ACF.php
+++ b/src/Directives/ACF.php
@@ -61,11 +61,11 @@ return [
         if (Str::contains($expression, ',')) {
             $expression = Util::parse($expression);
 
-            if (! empty($expression->get(2)) && is_numeric($expression->get(2))) {
+            if (! empty($expression->get(2)) && Util::isPostID($expression->get(2))) {
                 return "<?= get_field({$expression->get(0)}, {$expression->get(2)})[{$expression->get(1)}]; ?>";
             }
 
-            if (is_numeric($expression->get(1))) {
+            if (Util::isPostID($expression->get(1))) {
                 return "<?= get_field({$expression->get(0)}, {$expression->get(1)}); ?>";
             }
 
@@ -79,11 +79,11 @@ return [
         if (Str::contains($expression, ',')) {
             $expression = Util::parse($expression);
 
-            if (! empty($expression->get(2)) && is_numeric($expression->get(2))) {
+            if (! empty($expression->get(2)) && Util::isPostID($expression->get(2))) {
                 return "<?php if (get_field({$expression->get(0)}, {$expression->get(2)})[{$expression->get(1)}]) : ?>";
             }
 
-            if (is_numeric($expression->get(1))) {
+            if (Util::isPostID($expression->get(1))) {
                 return "<?php if (get_field({$expression->get(0)}, {$expression->get(1)})) : ?>";
             }
 
@@ -97,15 +97,15 @@ return [
         if (Str::contains($expression, ',')) {
             $expression = Util::parse($expression);
 
-            if (! empty($expression->get(3)) && is_numeric($expression->get(2))) {
+            if (! empty($expression->get(3)) && Util::isPostID($expression->get(2))) {
                 return "<?php if (get_field({$expression->get(0)}, {$expression->get(3)})[{$expression->get(1)}] === {$expression->get(2)}) : ?>"; // phpcs:ignore
             }
 
-            if (! empty($expression->get(2)) && is_numeric($expression->get(2))) {
+            if (! empty($expression->get(2)) && Util::isPostID($expression->get(2))) {
                 return "<?php if (get_field({$expression->get(0)}, {$expression->get(2)}) === {$expression->get(1)}) : ?>"; // phpcs:ignore
             }
 
-            if (! empty($expression->get(2)) && ! is_numeric($expression->get(2))) {
+            if (! empty($expression->get(2)) && ! Util::isPostID($expression->get(2))) {
                 return "<?php if (get_field({$expression->get(0)})[{$expression->get(2)}] === {$expression->get(1)}) : ?>"; // phpcs:ignore
             }
 

--- a/src/Directives/ACF.php
+++ b/src/Directives/ACF.php
@@ -61,11 +61,11 @@ return [
         if (Str::contains($expression, ',')) {
             $expression = Util::parse($expression);
 
-            if (! empty($expression->get(2)) && ! is_string($expression->get(2))) {
+            if (! empty($expression->get(2)) && is_numeric($expression->get(2))) {
                 return "<?= get_field({$expression->get(0)}, {$expression->get(2)})[{$expression->get(1)}]; ?>";
             }
 
-            if (! is_string($expression->get(1))) {
+            if (is_numeric($expression->get(1))) {
                 return "<?= get_field({$expression->get(0)}, {$expression->get(1)}); ?>";
             }
 
@@ -79,11 +79,11 @@ return [
         if (Str::contains($expression, ',')) {
             $expression = Util::parse($expression);
 
-            if (! empty($expression->get(2)) && ! is_string($expression->get(2))) {
+            if (! empty($expression->get(2)) && is_numeric($expression->get(2))) {
                 return "<?php if (get_field({$expression->get(0)}, {$expression->get(2)})[{$expression->get(1)}]) : ?>";
             }
 
-            if (! is_string($expression->get(1))) {
+            if (is_numeric($expression->get(1))) {
                 return "<?php if (get_field({$expression->get(0)}, {$expression->get(1)})) : ?>";
             }
 
@@ -97,15 +97,15 @@ return [
         if (Str::contains($expression, ',')) {
             $expression = Util::parse($expression);
 
-            if (! empty($expression->get(3)) && ! is_string($expression->get(2))) {
+            if (! empty($expression->get(3)) && is_numeric($expression->get(2))) {
                 return "<?php if (get_field({$expression->get(0)}, {$expression->get(3)})[{$expression->get(1)}] === {$expression->get(2)}) : ?>"; // phpcs:ignore
             }
 
-            if (! empty($expression->get(2)) && ! is_string($expression->get(2))) {
+            if (! empty($expression->get(2)) && is_numeric($expression->get(2))) {
                 return "<?php if (get_field({$expression->get(0)}, {$expression->get(2)}) === {$expression->get(1)}) : ?>"; // phpcs:ignore
             }
 
-            if (! empty($expression->get(2)) && is_string($expression->get(2))) {
+            if (! empty($expression->get(2)) && ! is_numeric($expression->get(2))) {
                 return "<?php if (get_field({$expression->get(0)})[{$expression->get(2)}] === {$expression->get(1)}) : ?>"; // phpcs:ignore
             }
 

--- a/src/Utilities.php
+++ b/src/Utilities.php
@@ -163,4 +163,17 @@ class Util
 
         return Str::startsWith($expression, '[') && Str::endsWith($expression, ']');
     }
+
+    /**
+     * An attempt to identify WP_POST or IDs that are passed into the directives.
+     *
+     * @param string $expression
+     * @return boolean
+     */
+    public static function isPostID($expression)
+    {
+        $expression = self::strip($expression);
+
+        return is_numeric($expression) || in_array($expression, ['get_the_ID()','$post->ID','get_queried_object_id()']);
+    }
 }


### PR DESCRIPTION
Switching to `is_numeric` to identify ID values from strings, since the blade template is always parsed as a string and `is_string` wasn't catching IDs.

This may however need more to really fix it. This will handle any cases when someone passes in a number directly, but does not handle variables or function calls, which might happen. 

Fixes #44
Fixes #63