### PR TITLE
Add third parameter to the get_the_post_thumbnail call when it isn't boolean

### DIFF
--- a/docs/usage/wordpress.md
+++ b/docs/usage/wordpress.md
@@ -183,6 +183,12 @@ To echo the featured image URL (without img markup), you can pass `false` as the
 <img src="@thumbnail(get_post(1), 'full', false)" alt="Post 1's Full Image" />
 ```
 
+If you need access to the `<img>` tag attributes directly, use an array as the last parameter instead:
+
+```php
+@thumbnail(get_post(1), 'full', ['class' => 'w-full rounded-lg'])
+```
+
 ## @author
 
 `@author` echo's the author of the current posts display name.

--- a/src/Directives/WordPress.php
+++ b/src/Directives/WordPress.php
@@ -174,7 +174,7 @@ return [
                     return "<?= get_the_post_thumbnail_url({$expression->get(0)}, is_numeric({$expression->get(1)}) ? [{$expression->get(1)}, {$expression->get(1)}] : {$expression->get(1)}); ?>"; // phpcs:ignore
                 }
 
-                return "<?= get_the_post_thumbnail({$expression->get(0)}, is_numeric({$expression->get(1)}) ? [{$expression->get(1)}, {$expression->get(1)}] : {$expression->get(1)}); ?>"; // phpcs:ignore
+                return "<?= get_the_post_thumbnail({$expression->get(0)}, is_numeric({$expression->get(1)}) ? [{$expression->get(1)}, {$expression->get(1)}] : {$expression->get(1)}, {$expression->get(2)}); ?>"; // phpcs:ignore
             }
 
             if (! empty($expression->get(1))) {


### PR DESCRIPTION
This PR should fix the issue with the third parameter when it is passing an attr 

Fixes #73