### PR TITLE
fix(directive): Fix `@published` and `@modified` directives with custom date format (Fixes #57)

### DIFF
--- a/src/Directives/Helpers.php
+++ b/src/Directives/Helpers.php
@@ -189,10 +189,7 @@ return [
 
     'implode' => function ($expression) {
         if (Str::contains($expression, ',')) {
-            $expression = str_replace(['\', \'', '\',\''], ['\'*\'', '\'* \''], $expression);
             $expression = Util::parse($expression);
-
-            $expression->put(0, str_replace(['\'*\'', '\'* \''], ['\', \'', '\',\''], $expression->get(0)));
 
             return "<?php echo implode({$expression->get(0)}, {$expression->get(1)}); ?>";
         }

--- a/src/Directives/WordPress.php
+++ b/src/Directives/WordPress.php
@@ -229,11 +229,17 @@ return [
 
     'published' => function ($expression) {
         if (! empty($expression)) {
-            return "<?php if (is_a({$expression}, 'WP_Post') || is_int({$expression})) : ?>".
-                   "<?php echo get_the_date('', {$expression}); ?>".
-                   '<?php else : ?>'.
-                   "<?php echo get_the_date({$expression}); ?>".
-                   '<?php endif; ?>';
+            $expression = Util::parse($expression);
+
+            if (Util::isIdentifier($expression->get(0))) {
+                return "<?php echo get_the_date('', {$expression->get(0)}); ?>";
+            }
+
+            if (! Util::isIdentifier($expression->get(0)) && empty($expression->get(1))) {
+                return "<?php echo get_the_date({$expression->get(0)}); ?>";
+            }
+
+            return "<?php echo get_the_date({$expression->get(0)}, {$expression->get(1)}); ?>";
         }
 
         return '<?php echo get_the_date(); ?>';
@@ -241,11 +247,17 @@ return [
 
     'modified' => function ($expression) {
         if (! empty($expression)) {
-            return "<?php if (is_a({$expression}, 'WP_Post') || is_numeric({$expression})) : ?>".
-                   "<?php echo get_the_modified_date('', {$expression}); ?>".
-                   '<?php else : ?>'.
-                   "<?php echo get_the_modified_date({$expression}); ?>".
-                   '<?php endif; ?>';
+            $expression = Util::parse($expression);
+
+            if (Util::isIdentifier($expression->get(0))) {
+                return "<?php echo get_the_modified_date('', {$expression->get(0)}); ?>";
+            }
+
+            if (Util::isIdentifier($expression->get(1))) {
+                return "<?php echo get_the_modified_date({$expression->get(0)}, {$expression->get(1)}); ?>";
+            }
+
+            return "<?php echo get_the_modified_date({$expression->get(0)}); ?>";
         }
 
         return '<?php echo get_the_modified_date(); ?>';

--- a/src/Util.php
+++ b/src/Util.php
@@ -11,12 +11,18 @@ class Util
      *
      * @param  string  $expression
      * @param  int  $limit
+     * @param  string  $delimiter
      * @return \Illuminate\Support\Collection
      */
-    public static function parse($expression, $limit = PHP_INT_MAX)
+    public static function parse($expression, $limit = PHP_INT_MAX, $delimiter = '__comma__')
     {
+        $expression = preg_replace_callback('/\'(.*?)\'|"(.*?)"/', function ($matches) use ($delimiter) {
+            return str_replace(',', $delimiter, $matches[0]);
+        }, $expression);
+
         return collect(explode(',', $expression, $limit))
-            ->map(function ($item) {
+            ->map(function ($item) use ($delimiter) {
+                $item = str_replace($delimiter, ',', $item);
                 $item = trim($item);
 
                 if (is_numeric($item)) {

--- a/tests/Unit/WordPressTest.php
+++ b/tests/Unit/WordPressTest.php
@@ -282,7 +282,23 @@ describe('@published', function () {
 
         $compiled = $this->compile($directive);
 
-        expect($compiled)->toBe("<?php if (is_a(1, 'WP_Post') || is_int(1)) : ?><?php echo get_the_date('', 1); ?><?php else : ?><?php echo get_the_date(1); ?><?php endif; ?>");
+        expect($compiled)->toBe("<?php echo get_the_date('', 1); ?>");
+    });
+
+    it('compiles correctly with format', function () {
+        $directive = "@published('F j, Y')";
+
+        $compiled = $this->compile($directive);
+
+        expect($compiled)->toBe("<?php echo get_the_date('F j, Y'); ?>");
+    });
+
+    it('compiles correctly with post and format', function () {
+        $directive = "@published('F j, Y', 1)";
+
+        $compiled = $this->compile($directive);
+
+        expect($compiled)->toBe("<?php echo get_the_date('F j, Y', 1); ?>");
     });
 });
 
@@ -300,7 +316,23 @@ describe('@modified', function () {
 
         $compiled = $this->compile($directive);
 
-        expect($compiled)->toBe("<?php if (is_a(1, 'WP_Post') || is_numeric(1)) : ?><?php echo get_the_modified_date('', 1); ?><?php else : ?><?php echo get_the_modified_date(1); ?><?php endif; ?>");
+        expect($compiled)->toBe("<?php echo get_the_modified_date('', 1); ?>");
+    });
+
+    it('compiles correctly with format', function () {
+        $directive = "@modified('F j, Y')";
+
+        $compiled = $this->compile($directive);
+
+        expect($compiled)->toBe("<?php echo get_the_modified_date('F j, Y'); ?>");
+    });
+
+    it('compiles correctly with post and format', function () {
+        $directive = "@modified('F j, Y', 1)";
+
+        $compiled = $this->compile($directive);
+
+        expect($compiled)->toBe("<?php echo get_the_modified_date('F j, Y', 1); ?>");
     });
 });
 


### PR DESCRIPTION
- fix(directive): Fix `@published` and `@modified` directives with custom date format (Fixes #57)
- enhance(util): Improve the parse utility when dealing with delimiters
- chore(test): Add tests for `@published` and `@modified` using custom date format
- chore(directive): Remove unnecessary `str_replace` on implode