### PR TITLE
enhance(directives): Improved Blade `$loop` variable support

### DIFF
--- a/docs/usage/wordpress.md
+++ b/docs/usage/wordpress.md
@@ -16,6 +16,8 @@ The following directives are specific to WordPress core functionality.
 
 `@posts` begins the post loop and by default, assumes that `WP_Query` is set to `$query` (which is the case when using `@query`). It is wrapped in a `have_posts()` conditional and thus will return `null` if no posts are found.
 
+Inside of the `@posts` loop you have full access to the [Blade Loop Variable](https://laravel.com/docs/10.x/blade#the-loop-variable).
+
 `@endposts` is available to end your loop and `have_posts()` conditional as well as resetting your loop with [`wp_reset_postdata()`](https://developer.wordpress.org/reference/functions/wp_reset_postdata/).
 
 ```php

--- a/src/Directives/Helpers.php
+++ b/src/Directives/Helpers.php
@@ -203,19 +203,14 @@ return [
     */
 
     'repeat' => function ($expression) {
-        return "<?php for (\$iteration = 0 ; \$iteration < (int) {$expression}; \$iteration++) : ?>".
-               "<?php \$loop = (object) [
-                   'index' => \$iteration,
-                   'iteration' => \$iteration + 1,
-                   'remaining' =>  (int) {$expression} - \$iteration,
-                   'count' => (int) {$expression},
-                   'first' => \$iteration === 0,
-                   'last' => \$iteration + 1 === (int) {$expression}
-               ]; ?>";
+        $initLoop = "\$__currentLoopData = range(1, {$expression}); \$__env->addLoop(\$__currentLoopData);";
+        $iterateLoop = '$__env->incrementLoopIndices(); $loop = $__env->getLastLoop();';
+
+        return "<?php {$initLoop} foreach(\$__currentLoopData as \$__i) : {$iterateLoop} ?>";
     },
 
     'endrepeat' => function () {
-        return '<?php endfor; ?>';
+        return '<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); ?>';
     },
 
     /*

--- a/tests/Unit/HelpersTest.php
+++ b/tests/Unit/HelpersTest.php
@@ -236,7 +236,7 @@ describe('@repeat', function () {
 
         $compiled = $this->compile($directive);
 
-        expect($compiled)->toBe("<?php for (\$iteration = 0 ; \$iteration < (int) 5; \$iteration++) : ?><?php \$loop = (object) [ 'index' => \$iteration, 'iteration' => \$iteration + 1, 'remaining' =>(int) 5 - \$iteration, 'count' => (int) 5, 'first' => \$iteration === 0, 'last' => \$iteration + 1 === (int) 5 ]; ?>");
+        expect($compiled)->toBe("<?php \$__currentLoopData = range(1, 5); \$__env->addLoop(\$__currentLoopData); foreach(\$__currentLoopData as \$__i) : \$__env->incrementLoopIndices(); \$loop = \$__env->getLastLoop(); ?>");
     });
 });
 
@@ -246,7 +246,7 @@ describe('@endrepeat', function () {
 
         $compiled = $this->compile($directive);
 
-        expect($compiled)->toBe('<?php endfor; ?>');
+        expect($compiled)->toBe('<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); ?>');
     });
 });
 

--- a/tests/Unit/WordPressTest.php
+++ b/tests/Unit/WordPressTest.php
@@ -16,15 +16,23 @@ describe('@posts', function () {
 
         $compiled = $this->compile($directive);
 
-        expect($compiled)->toBe('<?php if (empty($query)) : ?><?php global $wp_query; ?><?php $query = $wp_query; ?><?php endif; ?><?php if ($query->have_posts()) : ?><?php while ($query->have_posts()) : $query->the_post(); ?>');
+        expect($compiled)->toBe("<?php if (empty(\$query)) : ?><?php global \$wp_query; ?><?php \$query = \$wp_query; ?><?php endif; ?> <?php if (\$query->have_posts()) : ?><?php \$__currentLoopData = range(1, \$query->post_count); \$__env->addLoop(\$__currentLoopData); while (\$query->have_posts()) : \$__env->incrementLoopIndices(); \$loop = \$__env->getLastLoop(); \$query->the_post(); ?>");
     });
 
-    it('compiles correctly with options array', function () {
-        $directive = "@posts(['post_type' => 'post'])";
+    it('compiles correctly with post ID', function () {
+        $directive = "@posts(1)";
 
         $compiled = $this->compile($directive);
 
-        expect($compiled)->toBe("<?php \$posts = collect(); ?><?php if (is_a(['post_type' => 'post'], 'WP_Post') || is_numeric(['post_type' => 'post'])) : ?><?php \$posts->put('p', is_a(['post_type' => 'post'], 'WP_Post') ? (['post_type' => 'post'])->ID : ['post_type' => 'post']); ?><?php endif; ?><?php if (is_array(['post_type' => 'post'])) : ?><?php \$posts ->put('ignore_sticky_posts', true) ->put('posts_per_page', -1) ->put('post__in', collect(['post_type' => 'post']) ->map(function (\$post) { return is_a(\$post, 'WP_Post') ? \$post->ID : \$post; })->all()) ->put('orderby', 'post__in'); ?><?php endif; ?><?php \$query = \$posts->isNotEmpty() ? new WP_Query(\$posts->all()) : ['post_type' => 'post']; ?><?php if (\$query->have_posts()) : while (\$query->have_posts()) : \$query->the_post(); ?>");
+        expect($compiled)->toBe("<?php \$posts = collect(); ?><?php if (is_a(1, 'WP_Post') || is_numeric(1)) : ?><?php \$posts->put('p', is_a(1, 'WP_Post') ? (1)->ID : 1); ?><?php endif; ?><?php if (is_array(1)) : ?><?php \$posts ->put('ignore_sticky_posts', true) ->put('posts_per_page', -1) ->put('post__in', collect(1) ->map(function (\$post) { return is_a(\$post, 'WP_Post') ? \$post->ID : \$post; })->all()) ->put('orderby', 'post__in'); ?><?php endif; ?><?php \$query = \$posts->isNotEmpty() ? new WP_Query(\$posts->all()) : 1; ?><?php if (\$query->have_posts()) : \$__currentLoopData = range(1, \$query->post_count); \$__env->addLoop(\$__currentLoopData); while (\$query->have_posts()) : \$__env->incrementLoopIndices(); \$loop = \$__env->getLastLoop(); \$query->the_post(); ?>");
+    });
+
+    it('compiles correctly with post ID array', function () {
+        $directive = "@posts([1, 2, 3])";
+
+        $compiled = $this->compile($directive);
+
+        expect($compiled)->toBe("<?php \$posts = collect(); ?><?php if (is_a([1, 2, 3], 'WP_Post') || is_numeric([1, 2, 3])) : ?><?php \$posts->put('p', is_a([1, 2, 3], 'WP_Post') ? ([1, 2, 3])->ID : [1, 2, 3]); ?><?php endif; ?><?php if (is_array([1, 2, 3])) : ?><?php \$posts ->put('ignore_sticky_posts', true) ->put('posts_per_page', -1) ->put('post__in', collect([1, 2, 3]) ->map(function (\$post) { return is_a(\$post, 'WP_Post') ? \$post->ID : \$post; })->all()) ->put('orderby', 'post__in'); ?><?php endif; ?><?php \$query = \$posts->isNotEmpty() ? new WP_Query(\$posts->all()) : [1, 2, 3]; ?><?php if (\$query->have_posts()) : \$__currentLoopData = range(1, \$query->post_count); \$__env->addLoop(\$__currentLoopData); while (\$query->have_posts()) : \$__env->incrementLoopIndices(); \$loop = \$__env->getLastLoop(); \$query->the_post(); ?>");
     });
 });
 
@@ -34,7 +42,7 @@ describe('@endposts', function () {
 
         $compiled = $this->compile($directive);
 
-        expect($compiled)->toBe('<?php endwhile; wp_reset_postdata(); endif; ?>');
+        expect($compiled)->toBe('<?php endwhile; wp_reset_postdata(); $__env->popLoop(); $loop = $__env->getLastLoop(); endif; ?>');
     });
 });
 


### PR DESCRIPTION
- enhance(directives): Add proper Blade `$loop` variable support to `@repeat`
- enhance(directives): Add Blade `$loop` variable support to `@posts` (Fixes #48)
- chore(test): Redo `@posts` tests for `$loop` support 
- fix(test): Fix invalid `@posts` test
- chore(test): Update the `@repeat` test for `$loop` support
- chore(docs): Add mention of `$loop` to the `@posts` docs section