### PR TITLE
Added @thememod directive

### DIFF
--- a/docs/usage/wordpress.md
+++ b/docs/usage/wordpress.md
@@ -535,3 +535,12 @@ It comes with two assisting directives `@hassidebar` and `@endhassidebar` that c
   @sidebar('sidebar-primary')
 @endhassidebar
 ```
+
+## @thememod
+
+`@thememod` echoes the result of [`get_theme_mod`](https://developer.wordpress.org/reference/functions/get_theme_mod/) function accepting theme modification name and optional default value
+
+```php
+@thememod('header-bg-color')
+@thememod('header-bg-color', '#fff')
+```

--- a/src/Directives/WordPress.php
+++ b/src/Directives/WordPress.php
@@ -631,7 +631,7 @@ return [
         $mod = $expression->get(0);
         $default = $expression->get(1);
 
-        if (!empty($default)) {
+        if (! empty($default)) {
             return "<?php echo get_theme_mod({$mod}, {$default}); ?>";
         }
 

--- a/src/Directives/WordPress.php
+++ b/src/Directives/WordPress.php
@@ -618,4 +618,23 @@ return [
 
         return "<?php _e({$expression[0]}, {$expression[1]}); ?>";
     },
+
+    /*
+    |---------------------------------------------------------------------
+    | @thememod
+    |---------------------------------------------------------------------
+    */
+
+    'thememod' => function ($expression) {
+        $expression = Util::parse($expression);
+
+        $mod = $expression->get(0);
+        $default = $expression->get(1);
+
+        if (!empty($default)) {
+            return "<?php echo get_theme_mod({$mod}, {$default}); ?>";
+        }
+
+        return "<?php echo get_theme_mod({$mod}); ?>";
+    },
 ];

--- a/tests/Unit/WordPressTest.php
+++ b/tests/Unit/WordPressTest.php
@@ -827,3 +827,21 @@ describe('@__', function () {
         expect($compiled)->toBe("<?php _e('Hello World', 'sage'); ?>");
     });
 });
+
+describe('@thememod', function () {
+    it('compiles correctly', function () {
+        $directive = "@thememod('mod')";
+
+        $compiled = $this->compile($directive);
+
+        expect($compiled)->toBe("<?php echo get_theme_mod('mod'); ?>");
+    });
+
+    it('compiles correctly with default value', function () {
+        $directive = "@thememod('mod', 'default')";
+
+        $compiled = $this->compile($directive);
+
+        expect($compiled)->toBe("<?php echo get_theme_mod('mod', 'default'); ?>");
+    });
+});


### PR DESCRIPTION
This PR adds `@thememod` directive which basically is [get_theme_mod](https://developer.wordpress.org/reference/functions/get_theme_mod/) function