### PR TITLE
fix(directive): Fix @image directive not re-compiling view when using ACF field

### DIFF
--- a/src/Directives/WordPress.php
+++ b/src/Directives/WordPress.php
@@ -432,7 +432,7 @@ return [
             ! Util::isIdentifier($image) &&
             $image = Util::field($image)
         ) {
-            $expression = $expression->put(0, is_array($image) && ! empty($image['id']) ? $image['id'] : $image);
+            $expression = $expression->put(0, is_array($image) && ! empty($image['id']) ? "get_field({$expression->get(0)})['id']" : "get_field({$expression->get(0)})");
         }
 
         if (Util::strip($expression->get(1)) == 'raw') {


### PR DESCRIPTION
When using @image directive with an ACF field name, the Blade view was not re-compiling after updating field value. This PR fixes this bug by moving the `get_field` call directly into the Blade echo rather than passing the field value.

Closes #117