### PR TITLE
Add @menu, @hasmenu and @endhasmenu

### DIFF
--- a/src/Directives/WordPress.php
+++ b/src/Directives/WordPress.php
@@ -639,8 +639,7 @@ class WordPress extends Directives
             */
 
             'menu' => function ($expression) {
-                $expression = $this->parse($expression);
-                return "<?php wp_nav_menu({$expression->get(0)}); ?>";
+                return "<?php wp_nav_menu($expression); ?>";
             },
 
             'hasmenu' => function ($expression) {

--- a/src/Directives/WordPress.php
+++ b/src/Directives/WordPress.php
@@ -631,6 +631,25 @@ class WordPress extends Directives
 
                 return "<?php echo get_theme_mod({$mod}); ?>";
             },
+
+            /*
+            |---------------------------------------------------------------------
+            | @menu / @hasmenu / @endhasmenu
+            |---------------------------------------------------------------------
+            */
+
+            'menu' => function ($expression) {
+                $expression = $this->parse($expression);
+                return "<?php wp_nav_menu({$expression->get(0)}); ?>";
+            },
+
+            'hasmenu' => function ($expression) {
+                return "<?php if (has_nav_menu($expression)) : ?>";
+            },
+
+            'endhasmenu' => function () {
+                return '<?php endif; ?>';
+            },
         ];
     }
 }

--- a/tests/Unit/WordPressTest.php
+++ b/tests/Unit/WordPressTest.php
@@ -845,3 +845,33 @@ describe('@thememod', function () {
         expect($compiled)->toBe("<?php echo get_theme_mod('mod', 'default'); ?>");
     });
 });
+
+describe('@menu', function () {
+    it('compiles correctly', function () {
+        $directive = "@menu(['theme_location' => 'primary_navigation'])";
+
+        $compiled = $this->compile($directive);
+
+        expect($compiled)->toBe("<?php wp_nav_menu(['theme_location' => 'primary_navigation']); ?>");
+    });
+});
+
+describe('@hasmenu', function () {
+    it('compiles correctly', function () {
+        $directive = "@hasmenu('primary_navigation')";
+
+        $compiled = $this->compile($directive);
+
+        expect($compiled)->toBe("<?php if (has_nav_menu('primary_navigation')) : ?>");
+    });
+});
+
+describe('@endhasmenu', function () {
+    it('compiles correctly', function () {
+        $directive = '@endhasmenu';
+
+        $compiled = $this->compile($directive);
+
+        expect($compiled)->toBe('<?php endif; ?>');
+    });
+});


### PR DESCRIPTION
I love using your directives in blade files, but this one was missing for a while and I was initially debating about its utility, but I find myself not using Navi on smaller projects but hate using @php or passing ['echo' => false] in the arguments just to have those ugly exclamation brackets to echo it {!! !!}.

Conversations could be had about having @menu be smarter and do the "has_nav_menu" automatically which is the "normally expected behavior" (the nav location you call doesn't have anything = don't show anything), but in reality WordPress acquainted people could be thrown off by this since wp_nav_menu does some internal checks to always have something output in the navigation when the location has nothing in it like displaying the website's pages when no menu location has been set, thus allowing people to preview themes more easily. And so, I ended up deciding against it to keep this simple, but you be the final judge!

Tested locally on a real project, PHP 8.2, WordPress 6.5.

Thanks for looking at this.